### PR TITLE
Add a delayed load function to improve performance

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{ 
+  "semi": false,
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -28,5 +28,22 @@ Vue.use(VueSegmentAnalytics, {
 })
 ```
 
+## Performance Improvements
+Inspired by: https://www.gatsbyjs.org/blog/2019-08-30-speed-up-your-time-to-interactive-by-delaying-third-party-scripts/
+
+1. Wait for the user to scroll
+2. Do a setTimeout for 1 second
+3. Wrap the call in a requestIdleCallback, if supported
+4. Then load the script
+
+### Config Options
+
+`delayLoad` - Set to true to enable above improvements. Defaults to `false`
+`delayLoadTime` - Time in ms to delay loading script. `delayLoad` must be enabled. Defaults to `1000`
+
+### Known Issues
+
+The above performance options will effect your bounce rate since it won't be detected until segment finishes loading.
+
 ## 🚀 Segment Vue Quickstart
 Interested in writing analytics code once? With Segment, you can collect customer data from any source (web, mobile, server, CRM, etc.) and send it to over 250+ destinations (Google Analytics, Amplitude, Mixpanel, etc.) via the Segment dashboard. Follow the [tailored guide for Vue](https://github.com/segmentio/analytics-vue) to get setup.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Inspired by: https://www.gatsbyjs.org/blog/2019-08-30-speed-up-your-time-to-inte
 ### Config Options
 
 `delayLoad` - Set to true to enable above improvements. Defaults to `false`
+
 `delayLoadTime` - Time in ms to delay loading script. `delayLoad` must be enabled. Defaults to `1000`
 
 ### Known Issues

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-segment-analytics",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-segment-analytics",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Vue plugin for segment analytics.js",
   "main": "dist/vue-segment-analytics.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -5,31 +5,44 @@ import init from './init'
  * @param  {Vue instance} Vue
  * @param  {Object} [options={}]
  */
-function install (Vue, options = {}) {
-  const config = Object.assign({
-    debug: false,
-    pageCategory: '',
-  }, options)
+function install(Vue, options = {}) {
+  const config = Object.assign(
+    {
+      debug: false,
+      pageCategory: '',
+    },
+    options
+  )
 
   let analytics = init(config, () => {})
-  
+
   // Page tracking
   if (config.router !== undefined) {
     config.router.afterEach((to, from) => {
-      // Make a page call for each navigation event
-      window.analytics.page(config.pageCategory, to.name || '', {
-        path: to.fullPath,
-        referrer: from.fullPath
-      })
+      if (!analytics && from) {
+        // If page is changed before scroll, load segment now.
+        config.delayLoad = false
+        analytics = init(config, () => {})
+      } else {
+        // Make a page call for each navigation event
+        window.analytics.page(config.pageCategory, to.name || '', {
+          path: to.fullPath,
+          referrer: from.fullPath,
+        })
+      }
     })
   }
 
   // Setup instance access
   Object.defineProperty(Vue, '$segment', {
-    get () { return window.analytics }
+    get() {
+      return window.analytics
+    },
   })
   Object.defineProperty(Vue.prototype, '$segment', {
-    get () { return window.analytics }
+    get() {
+      return window.analytics
+    },
   })
 }
 


### PR DESCRIPTION
Inspired by https://github.com/benjaminhoffman/gatsby-plugin-segment-js/pull/19

1. Wait for the user to scroll
2. Do a setTimeout for 1 second
3. Wrap the call in a requestIdleCallback, if supported
4. Then load the script

### Config Options

`delayLoad` - Set to true to enable above improvements. Defaults to `false`
`delayLoadTime` - Time in ms to delay loading script. `delayLoad` must be enabled. Defaults to `1000`